### PR TITLE
Feature/skiptest for getcreds

### DIFF
--- a/src/Aks/private/Aks-Utilities.ps1
+++ b/src/Aks/private/Aks-Utilities.ps1
@@ -376,7 +376,7 @@ function Update-ClusterResources($aksClusters) {
 # Function to populate catalog of management actions
 function Get-ManagementActions {
     [ManagementAction[]] $managementActions = @()
-    $managementActions += [ManagementAction]::new("Get-KubectlCredentialsForAksClusters", "Get kubectl credentials for the selected AKS cluster(s)", { param ($aksClusters, $ProxyUrl, $SkipProxyAll, $SetupAllWithDefaults) Get-KubectlCredentialsForAksClusters $aksClusters $ProxyUrl -SkipProxyAll:$SkipProxyAll -SetupAllWithDefaults:$SetupAllWithDefaults -SkipTestConnections })
+    $managementActions += [ManagementAction]::new("Get-KubectlCredentialsForAksClusters", "Get kubectl credentials for the selected AKS cluster(s)", { param ($aksClusters, $ProxyUrl, $SkipProxyAll, $SetupAllWithDefaults) Get-KubectlCredentialsForAksClusters $aksClusters $ProxyUrl -SkipProxyAll:$SkipProxyAll -SetupAllWithDefaults:$SetupAllWithDefaults -SkipTestConnections:$SkipTestConnections })
     $managementActions += [ManagementAction]::new("Test-ConnectionsToAksClusters", "Test connection(s) to the selected AKS cluster(s) using kubectl version command", { param ($aksClusters) Test-ConnectionsToAksClusters $aksClusters })
     $managementActions += [ManagementAction]::new("Get-ClusterResourceIds", "Get the resource ID(s) of the selected AKS cluster(s)", { param ($aksClusters) Get-ClusterResourceIds $aksClusters })
     $managementActions += [ManagementAction]::new("`e[31m!!`e[0m Update-ClusterResources", "Update the selected AKS cluster resource(s) by ID(s)", { param ($aksClusters) Update-ClusterResources $aksClusters })


### PR DESCRIPTION
This pull request introduces a new parameter to the `Get-KubectlCredentialsForAksClusters` function and updates related functions to accommodate this change. The most important changes include the addition of the `SkipTestConnections` parameter and updates to the `Invoke-ClusterAction` function to support this new parameter.

### Parameter Addition:

* [`src/Aks/private/Aks-Utilities.ps1`](diffhunk://#diff-9b97bf4bc44a062f85bb6f15240b652ea0bd2c9bda8cd2a47f5396db46c4fd40L379-R379): Added `-SkipTestConnections:$SkipTestConnections` to the `Get-KubectlCredentialsForAksClusters` function call to allow skipping test connections.

### Function Updates:

* [`src/Aks/private/Aks-Utilities.ps1`](diffhunk://#diff-9b97bf4bc44a062f85bb6f15240b652ea0bd2c9bda8cd2a47f5396db46c4fd40L393-R394): Updated the `Invoke-ClusterAction` function to include the `SkipTestConnections` switch parameter.